### PR TITLE
switch mysql to use 4 byte compatible utf8

### DIFF
--- a/mmg/settings/development.py
+++ b/mmg/settings/development.py
@@ -119,6 +119,9 @@ DATABASES = {
         'PASSWORD': env('DB_PASSWORD'),
         'HOST': '127.0.0.1',
         'PORT': '3306',
+        'OPTIONS': {
+            'charset': 'utf8mb4'
+        },
     }
 }
 

--- a/mmg/settings/production.py
+++ b/mmg/settings/production.py
@@ -89,6 +89,7 @@ DATABASES = {
         'NAME': 'mholloway$movie_club',
         'OPTIONS': {
             'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+            'charset': 'utf8mb4'
             },
         'USER': os.getenv('DATABASE_USER'),
         'PASSWORD': os.getenv('DATABASE_PASSWORD'),


### PR DESCRIPTION
can't submit emojis in movie comments because mysql doesn't use 4 byte utf8? ok boss.

you may need to do something like

`ALTER DATABASE mmg_1 CHARACTER SET utf8mb4 COLLATE = utf8mb4_unicode_ci;`

on the prod database for this change to work.

test by trying to submit an emoji as a comment on a movie